### PR TITLE
Minor improvements for continuous operation use case

### DIFF
--- a/pkg/h10/helpers.go
+++ b/pkg/h10/helpers.go
@@ -1,7 +1,9 @@
 package h10
 
 import (
+	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 )
 
@@ -84,4 +86,11 @@ func decodeECGData(data []byte) (ECGMeasurement, error) {
 		timestamp: sampleTimestamp,
 		samples:   ecgSamples,
 	}, nil
+}
+
+func suppressCancellationError(err error) error {
+	if errors.Is(err, context.Canceled) {
+		return nil
+	}
+	return err
 }


### PR DESCRIPTION
1. Moved check for unbuffered channel earlier. Channel capacity cannot be changed after creation, so it does not make sense to check it on every message.
2. Removed hardcoded timeout. It does not make sense anyway, since context with deadline achieves the same result.
3. Refactored `streamNotification`. Previous implementation had few issues:
   * Missing feedback whether we've subscribed or not to notifications.
   * It was possible for `WaitGroup` to go negative, triggering the `panic`.